### PR TITLE
Improve workload cluster case handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added finalizer management for default dex config secret.
 - Added `README.md`.
 - Added azure active directory provider.
 - Added initial implementation of the dex operator.

--- a/pkg/idp/idp.go
+++ b/pkg/idp/idp.go
@@ -189,7 +189,7 @@ func (s *Service) GetAppConfig(ctx context.Context) (provider.AppConfig, error) 
 				return provider.AppConfig{}, err
 			}
 			// Get the base domain
-			baseDomain = clusterValuesConfigmap.Data[key.BaseDomainKey]
+			baseDomain = getBaseDomainFromClusterValues(clusterValuesConfigmap)
 		}
 		// Vintage management cluster case
 		if baseDomain == "" {

--- a/pkg/idp/util.go
+++ b/pkg/idp/util.go
@@ -1,11 +1,14 @@
 package idp
 
 import (
+	"fmt"
 	"giantswarm/dex-operator/pkg/key"
 	"reflect"
+	"regexp"
 	"strings"
 
 	"github.com/giantswarm/apiextensions-application/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 func dexSecretConfigIsPresent(app *v1alpha1.App, dexSecretConfig v1alpha1.AppExtraConfig) bool {
@@ -22,6 +25,15 @@ func dexSecretConfigIsPresent(app *v1alpha1.App, dexSecretConfig v1alpha1.AppExt
 
 func clusterValuesIsPresent(app *v1alpha1.App) bool {
 	return strings.HasSuffix(app.Spec.Config.ConfigMap.Name, key.ClusterValuesConfigmapSuffix)
+}
+
+func getBaseDomainFromClusterValues(clusterValuesConfigmap *corev1.ConfigMap) string {
+	values := clusterValuesConfigmap.Data[key.ClusterValuesConfigMapKey]
+	rex := regexp.MustCompile(fmt.Sprintf(`(%v)(\s*:\s*)(\S+)`, key.BaseDomainKey))
+	if matches := rex.FindStringSubmatch(values); len(matches) > 3 {
+		return matches[3]
+	}
+	return ""
 }
 
 func GetDexSecretConfig(namespace string) v1alpha1.AppExtraConfig {

--- a/pkg/key/key.go
+++ b/pkg/key/key.go
@@ -13,6 +13,7 @@ const (
 	DexOperatorFinalizer         = "dex-operator.finalizers.giantswarm.io"
 	DexOperatorLabelValue        = "dex-operator"
 	ClusterValuesConfigmapSuffix = "cluster-values"
+	ClusterValuesConfigMapKey    = "values"
 	BaseDomainKey                = "baseDomain"
 	DexResourceURI               = "https://dex.giantswarm.io"
 )

--- a/pkg/key/key.go
+++ b/pkg/key/key.go
@@ -10,7 +10,7 @@ const (
 	AppLabel                     = "app.kubernetes.io/name"
 	DexAppLabelValue             = "dex-app"
 	DexConfigName                = "default-dex-config"
-	DexOperatorFinalizer         = "dex-operator.finalizers.giantswarm.io"
+	DexOperatorFinalizer         = "dex-operator.finalizers.giantswarm.io/app-controller"
 	DexOperatorLabelValue        = "dex-operator"
 	ClusterValuesConfigmapSuffix = "cluster-values"
 	ClusterValuesConfigMapKey    = "values"


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/1596
This solves two problems with dex apps installed on workload clusters.
- Fixes issue where baseDomain can not be found in cluster values configmap by using regex match.
- Fixes issue where leftovers stay on the idp in case the cluster is just deleted instead of app deinstalled by adding finalizer to the secret