### PR TITLE
push to capi app collections

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,6 @@ workflows:
             ignore: /.*/
           tags:
             only: /^v.*/
-
     - architect/push-to-app-collection:
         context: architect
         name: push-to-aws-app-collection
@@ -109,7 +108,6 @@ workflows:
             ignore: /.*/
           tags:
             only: /^v.*/
-
     - architect/push-to-app-collection:
         context: architect
         name: push-to-kvm-app-collection
@@ -117,6 +115,54 @@ workflows:
         app_collection_repo: "kvm-app-collection"
         requires:
         - push-to-app-catalog
+        filters:
+          branches:
+            ignore: /.*/
+          tags:
+            only: /^v.*/
+    - architect/push-to-app-collection:
+        context: architect
+        name: push-to-cloud-director-app-collection
+        app_name: "dex-operator"
+        app_collection_repo: cloud-director-app-collection
+        requires:
+          - push-to-app-catalog
+        filters:
+          branches:
+            ignore: /.*/
+          tags:
+            only: /^v.*/
+    - architect/push-to-app-collection:
+        context: architect
+        name: push-to-capa-app-collection
+        app_name: "dex-operator"
+        app_collection_repo: "capa-app-collection"
+        requires:
+          - push-to-app-catalog
+        filters:
+          branches:
+            ignore: /.*/
+          tags:
+            only: /^v.*/
+    - architect/push-to-app-collection:
+        context: architect
+        name: push-to-gcp-app-collection
+        app_name: "dex-operator"
+        app_collection_repo: "gcp-app-collection"
+        requires:
+          - push-to-app-catalog
+        filters:
+          branches:
+            ignore: /.*/
+          tags:
+            only: /^v.*/
+    - architect/push-to-app-collection:
+        context: architect
+        name: push-to-openstack-app-collection
+        app_name: "dex-operator"
+        app_collection_repo: "openstack-app-collection"
+        requires:
+          - push-to-app-catalog
         filters:
           branches:
             ignore: /.*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Push to CAPI provider app collections
+- Allow empty list of providers
+- Raise memory usage limit to 500Mi
+
 ## [0.1.2] - 2022-12-06
 
 ### Changed

--- a/controllers/app_controller.go
+++ b/controllers/app_controller.go
@@ -157,7 +157,7 @@ func (r *AppReconciler) GetProviders() ([]provider.Provider, error) {
 		return nil, microerror.Mask(err)
 	}
 
-	var providers []provider.Provider
+	providers := []provider.Provider{}
 	{
 		for _, p := range providerCredentials {
 			provider, err := r.NewProvider(p)

--- a/helm/dex-operator/templates/deployment.yaml
+++ b/helm/dex-operator/templates/deployment.yaml
@@ -39,7 +39,7 @@ spec:
             memory: 220Mi
           limits:
             cpu: 100m
-            memory: 220Mi
+            memory: 500Mi
         volumeMounts:
         - mountPath: /home/.idp
           name: credentials


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/1717

This pushes the dex-operator to all capi provider app collections.
It also fixes two issues I have seen.
1. In one MC, `dex-operator` was OOMKilled as it required higher memory on start-up. Increased limit.
2. In another MC, no providers were found and an error was returned due to providers being nil. Changed to empty array.