### PR TITLE
Adjusted callback URL creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
 - Add use of runtime/default seccomp profile.
+
+### Changed
+
+- Added a new config parameter for issuer address
+- Adjusted creation of callback URL to prefer issuer address over base domain if possibe
 
 ## [0.1.4] - 2022-12-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Added a new config parameter for issuer address
-- Adjusted creation of callback URL to prefer issuer address over base domain if possibe
+- Adjusted creation of callback URL to prefer issuer address over base domain if possible
 
 ## [0.1.4] - 2022-12-21
 

--- a/controllers/app_controller.go
+++ b/controllers/app_controller.go
@@ -47,6 +47,7 @@ type AppReconciler struct {
 	Scheme              *runtime.Scheme
 	LabelSelector       metav1.LabelSelector
 	BaseDomain          string
+	IssuerAddress       string
 	ManagementCluster   string
 	ProviderCredentials string
 }
@@ -87,12 +88,13 @@ func (r *AppReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		}
 
 		c := idp.Config{
-			Log:                         &log,
-			Client:                      r.Client,
-			App:                         app,
-			Providers:                   providers,
-			ManagementClusterBaseDomain: r.BaseDomain,
-			ManagementClusterName:       r.ManagementCluster,
+			Log:                            &log,
+			Client:                         r.Client,
+			App:                            app,
+			Providers:                      providers,
+			ManagementClusterBaseDomain:    r.BaseDomain,
+			ManagementClusterIssuerAddress: r.IssuerAddress,
+			ManagementClusterName:          r.ManagementCluster,
 		}
 
 		idpService, err = idp.New(c)

--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	github.com/cjlapao/common-go v0.0.27 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.9.0 // indirect
+	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.6.0 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/giantswarm/micrologger v0.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -95,6 +95,7 @@ github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evanphx/json-patch v0.5.2/go.mod h1:ZWS5hhDbVDyob71nXKNL0+PWn6ToqBHMikGIFbs31qQ=
 github.com/evanphx/json-patch v4.12.0+incompatible h1:4onqiflcdA9EOZ4RxV643DvftH5pOlLGNtQ5lPWQu84=
+github.com/evanphx/json-patch v4.12.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.6.0 h1:b91NhWfaz02IuVxO9faSllyAtNXHMPkC5J8sJCLunww=
 github.com/evanphx/json-patch/v5 v5.6.0/go.mod h1:G79N1coSVB93tBe7j6PhzjmR3/2VvlbKOFpnXhI9Bw4=
 github.com/flowstack/go-jsonschema v0.1.1/go.mod h1:yL7fNggx1o8rm9RlgXv7hTBWxdBM0rVwpMwimd3F3N0=

--- a/helm/dex-operator/templates/deployment.yaml
+++ b/helm/dex-operator/templates/deployment.yaml
@@ -36,6 +36,7 @@ spec:
         - --leader-elect
         - --base-domain={{ .Values.baseDomain }}
         - --management-cluster={{ .Values.managementCluster }}
+        - --issuer-address={{ .Values.issuerAddress }}
         ports:
         - containerPort: 8080
           name: metrics

--- a/main.go
+++ b/main.go
@@ -52,6 +52,7 @@ func init() {
 func main() {
 	var (
 		baseDomain           string
+		issuerAddress        string
 		enableLeaderElection bool
 		idpCredentials       string
 		managementCluster    string
@@ -66,6 +67,7 @@ func main() {
 			"Enabling this will ensure there is only one active controller manager.")
 
 	flag.StringVar(&baseDomain, "base-domain", "", "Domain for the dex callback address, e.g. customer.gigantic.io.")
+	flag.StringVar(&issuerAddress, "issuer-address", "", "URL of the identity issuer")
 	flag.StringVar(&managementCluster, "management-cluster", "", "Name of the management cluster.")
 	opts := zap.Options{
 		Development: true,
@@ -102,6 +104,7 @@ func main() {
 
 	if err = (&controllers.AppReconciler{
 		BaseDomain:          baseDomain,
+		IssuerAddress:       issuerAddress,
 		ManagementCluster:   managementCluster,
 		Client:              mgr.GetClient(),
 		Log:                 ctrl.Log.WithName("controllers").WithName("App"),

--- a/pkg/idp/idp_test.go
+++ b/pkg/idp/idp_test.go
@@ -3,7 +3,9 @@ package idp
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"reflect"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"strconv"
 	"testing"
 
@@ -566,6 +568,93 @@ func TestSecretDataNeedsUpdate(t *testing.T) {
 	}
 }
 
+func TestGetAppConfig(t *testing.T) {
+	testCases := []struct {
+		name                           string
+		managementClusterName          string
+		managementClusterBaseDomain    string
+		managementClusterIssuerAddress string
+		app                            *v1alpha1.App
+		clusterValuesConfigMap         *corev1.ConfigMap
+		expectedAppConfig              provider.AppConfig
+	}{
+		{
+			name:                           "case 0: Get issuer URL from cluster config values",
+			managementClusterName:          "testcluster",
+			managementClusterBaseDomain:    "base.domain.io",
+			managementClusterIssuerAddress: "https://issuer.cluster.base.domain.io",
+			app:                            getExampleApp(),
+			clusterValuesConfigMap:         getClusterValuesConfigMap("baseDomain: wc.cluster.domain.io"),
+			expectedAppConfig: provider.AppConfig{
+				Name:          "testcluster-example-test",
+				RedirectURI:   "https://dex.wc.cluster.domain.io/callback",
+				IdentifierURI: "https://dex.giantswarm.io/testcluster-example-test",
+			},
+		},
+		{
+			name:                           "case 1: Get issuer URL from management cluster issuer URL property",
+			managementClusterName:          "testcluster",
+			managementClusterBaseDomain:    "base.domain.io",
+			managementClusterIssuerAddress: "https://issuer.cluster.domain.io",
+			app:                            getExampleApp(),
+			expectedAppConfig: provider.AppConfig{
+				Name:          "testcluster-example-test",
+				RedirectURI:   "https://issuer.cluster.domain.io/callback",
+				IdentifierURI: "https://dex.giantswarm.io/testcluster-example-test",
+			},
+		},
+		{
+			name:                        "case 2: Get issuer URL from management cluster base domain",
+			managementClusterName:       "testcluster",
+			managementClusterBaseDomain: "base.domain.io",
+			app:                         getExampleApp(),
+			expectedAppConfig: provider.AppConfig{
+				Name:          "testcluster-example-test",
+				RedirectURI:   "https://dex.g8s.base.domain.io/callback",
+				IdentifierURI: "https://dex.giantswarm.io/testcluster-example-test",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			ctx := context.Background()
+
+			fakeClientBuilder := fake.NewClientBuilder()
+			if tc.clusterValuesConfigMap != nil {
+				tc.app.Spec = v1alpha1.AppSpec{
+					Config: v1alpha1.AppSpecConfig{
+						ConfigMap: v1alpha1.AppSpecConfigConfigMap{
+							Name:      tc.clusterValuesConfigMap.Name,
+							Namespace: tc.clusterValuesConfigMap.Namespace,
+						},
+					},
+				}
+				fakeClientBuilder.WithObjects(tc.clusterValuesConfigMap)
+			}
+
+			service := Service{
+				Client:                         fakeClientBuilder.Build(),
+				log:                            ctrl.Log.WithName("test"),
+				app:                            tc.app,
+				managementClusterName:          tc.managementClusterName,
+				managementClusterBaseDomain:    tc.managementClusterBaseDomain,
+				managementClusterIssuerAddress: tc.managementClusterIssuerAddress,
+			}
+
+			appConfig, err := service.GetAppConfig(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !reflect.DeepEqual(appConfig, tc.expectedAppConfig) {
+				t.Fatalf("Expacted %v, got %v", tc.expectedAppConfig, appConfig)
+			}
+		})
+	}
+}
+
 func getExampleProvider(owner string) provider.Provider {
 	p, _ := mockprovider.New(provider.ProviderCredential{Owner: owner})
 	return p
@@ -576,6 +665,18 @@ func getExampleApp() *v1alpha1.App {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test",
 			Namespace: "example",
+		},
+	}
+}
+
+func getClusterValuesConfigMap(clusterValues string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("test-%s", key.ClusterValuesConfigmapSuffix),
+			Namespace: "example",
+		},
+		Data: map[string]string{
+			key.ClusterValuesConfigMapKey: clusterValues,
 		},
 	}
 }

--- a/pkg/idp/idp_test.go
+++ b/pkg/idp/idp_test.go
@@ -583,7 +583,7 @@ func TestGetAppConfig(t *testing.T) {
 			name:                           "case 0: Get issuer URL from cluster config values",
 			managementClusterName:          "testcluster",
 			managementClusterBaseDomain:    "base.domain.io",
-			managementClusterIssuerAddress: "https://issuer.cluster.base.domain.io",
+			managementClusterIssuerAddress: "issuer.cluster.base.domain.io",
 			app:                            getExampleApp(),
 			clusterValuesConfigMap:         getClusterValuesConfigMap("baseDomain: wc.cluster.domain.io"),
 			expectedAppConfig: provider.AppConfig{
@@ -596,7 +596,7 @@ func TestGetAppConfig(t *testing.T) {
 			name:                           "case 1: Get issuer URL from management cluster issuer URL property",
 			managementClusterName:          "testcluster",
 			managementClusterBaseDomain:    "base.domain.io",
-			managementClusterIssuerAddress: "https://issuer.cluster.domain.io",
+			managementClusterIssuerAddress: "issuer.cluster.domain.io",
 			app:                            getExampleApp(),
 			expectedAppConfig: provider.AppConfig{
 				Name:          "testcluster-example-test",

--- a/pkg/idp/idp_test.go
+++ b/pkg/idp/idp_test.go
@@ -5,9 +5,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"strconv"
 	"testing"
+
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"giantswarm/dex-operator/pkg/dex"
 	"giantswarm/dex-operator/pkg/idp/provider"

--- a/pkg/idp/util.go
+++ b/pkg/idp/util.go
@@ -73,22 +73,11 @@ func getConnectorsFromSecret(secret *corev1.Secret) (map[string]dex.Connector, e
 	if !exists {
 		return connectors, nil
 	}
-	config := &dex.DexConfig{}
-	if err := json.Unmarshal(configData, config); err != nil {
+	config := dex.DexConfig{}
+	if err := json.Unmarshal(configData, &config); err != nil {
 		return nil, microerror.Mask(err)
 	}
-
-	if config.Oidc.Customer != nil {
-		for _, connector := range config.Oidc.Customer.Connectors {
-			connectors[connector.ID] = connector
-		}
-	}
-	if config.Oidc.Giantswarm != nil {
-		for _, connector := range config.Oidc.Giantswarm.Connectors {
-			connectors[connector.ID] = connector
-		}
-	}
-	return connectors, nil
+	return getConnectorsFromConfig(config), nil
 }
 
 func getDexConfigFromSecret(secret *corev1.Secret) (dex.DexConfig, error) {

--- a/pkg/key/key.go
+++ b/pkg/key/key.go
@@ -44,7 +44,7 @@ func GetConnectorDescription(connectorType string, owner string) string {
 }
 
 func GetRedirectURI(issuerAddress string) string {
-	return fmt.Sprintf("%s/callback", issuerAddress)
+	return fmt.Sprintf("https://%s/callback", issuerAddress)
 }
 
 func GetIdentifierURI(name string) string {
@@ -52,7 +52,7 @@ func GetIdentifierURI(name string) string {
 }
 
 func GetIssuerAddress(clusterDomain string) string {
-	return fmt.Sprintf("https://dex.%s", clusterDomain)
+	return fmt.Sprintf("dex.%s", clusterDomain)
 }
 
 func GetVintageClusterDomain(baseDomain string) string {

--- a/pkg/key/key.go
+++ b/pkg/key/key.go
@@ -43,10 +43,18 @@ func GetConnectorDescription(connectorType string, owner string) string {
 	return fmt.Sprintf("%s connector for %s", connectorType, owner)
 }
 
-func GetRedirectURI(baseDomain string) string {
-	return fmt.Sprintf("https://dex.g8s.%s/callback", baseDomain)
+func GetRedirectURI(issuerAddress string) string {
+	return fmt.Sprintf("%s/callback", issuerAddress)
 }
 
 func GetIdentifierURI(name string) string {
 	return fmt.Sprintf("https://dex.giantswarm.io/%s", name)
+}
+
+func GetIssuerAddress(clusterDomain string) string {
+	return fmt.Sprintf("https://dex.%s", clusterDomain)
+}
+
+func GetVintageClusterDomain(baseDomain string) string {
+	return fmt.Sprintf("g8s.%s", baseDomain)
 }


### PR DESCRIPTION
In case a config map with cluster values is available, the operator gets the base domain from it and derives the callback URL from it. This approach works in workload clusters.

In case the config map is not available or if it has a different format (which is the case in management clusters), the operator uses the issuer address property to derive the callback URL.

And if the issuer address property is not available, the operator uses the base domain to derive the callback URL while assuming vintage format of the domain.