### PR TITLE
Style GitHub manifest flow UI

### DIFF
--- a/pkg/idp/provider/github/manifest/flow.go
+++ b/pkg/idp/provider/github/manifest/flow.go
@@ -128,6 +128,8 @@ func (f *Flow) run() error {
 			cancel()
 		})
 
+		mux.Handle("/static/", http.FileServer(http.FS(f.renderer.fs)))
+
 		server = &http.Server{
 			Addr:              fmt.Sprintf("localhost:%d", f.port),
 			Handler:           mux,

--- a/pkg/idp/provider/github/manifest/static/complete.tmpl
+++ b/pkg/idp/provider/github/manifest/static/complete.tmpl
@@ -1,5 +1,8 @@
 {{ define "content" }}
-<div class="center">
-  <h1>App {{.Content}} created!</h1>
+
+<div class="container">
+  <h1>App <code>{{.Content}}</code> created</h1>
+  <p>You can now close this browser window.</p>
 </div>
+
 {{ end }}

--- a/pkg/idp/provider/github/manifest/static/layout.tmpl
+++ b/pkg/idp/provider/github/manifest/static/layout.tmpl
@@ -1,15 +1,16 @@
 {{ define "layout" }}
+
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="stylesheet" href="/static/main.css">
-  <title>Github Manifest Flow</title>
-</head>
-<body>
-  {{ template "content" . }}
-</body>
-<script src="/static/main.js"></script>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="/static/main.css">
+    <title>GitHub Manifest Flow</title>
+  </head>
+  <body>
+    {{ template "content" . }}
+  </body>
 </html>
+
 {{ end }}

--- a/pkg/idp/provider/github/manifest/static/main.css
+++ b/pkg/idp/provider/github/manifest/static/main.css
@@ -1,1 +1,81 @@
-body {color: #c0392b}
+:root {
+  color: #333;
+  background-color: #efefef;
+  font-family: 'Source Sans Pro', Helvetica, sans-serif;
+  font-size: 16px;
+  font-weight: 400;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+* {
+  margin: 0;
+}
+
+body {
+  min-width: 320px;
+  min-height: 100vh;
+  padding-top: 45px;
+}
+
+h1 {
+  font-size: 1.3em;
+  line-height: 1.1;
+}
+
+input,
+button,
+textarea {
+  font: inherit;
+}
+
+button {
+  background-color: #333;
+  border-radius: 4px;
+  border: 0;
+  color: #fff;
+  font-size: 1em;
+  font-weight: 600;
+  font-family: inherit;
+  padding: 0.5em 1.5em;
+}
+
+button:hover {
+  background-color: #666;
+}
+
+code {
+  font-weight: 400;
+}
+
+textarea {
+  border-radius: 4px;
+  border: 0;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.2),
+    0 1px 2px rgba(0, 0, 0, 0.25), 0 0 1px rgba(0, 0, 0, 0.25);
+  font: monospace;
+  resize: none;
+}
+
+.container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1em;
+  box-shadow: 0 5px 15px rgba(0, 0, 0, 0.5);
+  background-color: #fff;
+  padding: 2em;
+  margin: 0 auto;
+  max-width: 500px;
+  min-width: 320px;
+}
+
+.creation-form {
+  gap: 2em;
+}

--- a/pkg/idp/provider/github/manifest/static/submit.tmpl
+++ b/pkg/idp/provider/github/manifest/static/submit.tmpl
@@ -1,7 +1,9 @@
 {{ define "content" }}
-<form action="{{ .URL }}" method="post">
-  <label>Create a GitHub App Manifest:</label>
-  <textarea cols="72" rows="25" name="manifest" id="manifest">{{ .Content }}</textarea><br>
- <input type="submit" value="Submit">
+
+<form action="{{ .URL }}" method="post" class="container creation-form">
+  <h1>Create a GitHub App Manifest</h1>
+  <textarea cols="50" rows="12" name="manifest" id="manifest">{{ .Content }}</textarea>
+  <button class="theme-btn--primary" type="submit">Submit</button>
 </form>
+
 {{ end }}

--- a/pkg/idp/provider/github/manifest/template.go
+++ b/pkg/idp/provider/github/manifest/template.go
@@ -23,8 +23,6 @@ type Renderer struct {
 }
 
 func newRenderer() *Renderer {
-	fs := http.FileServer(http.FS(embedded))
-	http.Handle("/static/", noCache(fs))
 	return &Renderer{fs: embedded}
 }
 


### PR DESCRIPTION
Add some styling to the GitHub manifest flow templates. I based it off of `dex-app`'s current login page, so it looks similarily minimal right now:

<img width="400" alt="Screenshot 2023-03-15 at 22 09 45" src="https://user-images.githubusercontent.com/62935115/225446835-78cc34c4-7214-427a-a5f4-73f256124c33.png">
<img width="400" alt="Screenshot 2023-03-15 at 22 20 13" src="https://user-images.githubusercontent.com/62935115/225446841-d6944498-25ad-4905-b913-e9da1a18086a.png">