### PR TITLE
Fix bugs in credential creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix bug where credential creation fails when parent directory is missing.
+- Omit empty fields in credential creation.
+
 ### Changed
 
 - Replace credential creation script with `opsctl create dexconfig`.

--- a/setup/config.go
+++ b/setup/config.go
@@ -8,18 +8,18 @@ import (
 )
 
 type Config struct {
-	Oidc Oidc `json:"oidc"`
+	Oidc Oidc `yaml:"oidc,omitempty"`
 }
 type Oidc struct {
-	Giantswarm OidcOwner `json:"giantswarm"`
-	Customer   OidcOwner `json:"customer"`
+	Giantswarm OidcOwner `yaml:"giantswarm,omitempty"`
+	Customer   OidcOwner `yaml:"customer,omitempty"`
 }
 type OidcOwner struct {
-	Providers []OidcOwnerProvider `json:"providers"`
+	Providers []OidcOwnerProvider `json:"providers,omitempty"`
 }
 type OidcOwnerProvider struct {
-	Name        string `json:"name"`
-	Credentials string `json:"credentials"`
+	Name        string `yaml:"name"`
+	Credentials string `yaml:"credentials"`
 }
 
 func GetConfigFromFile(fileLocation string) (Config, error) {

--- a/setup/setup.go
+++ b/setup/setup.go
@@ -2,6 +2,7 @@ package setup
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/giantswarm/dex-operator/controllers"
@@ -136,6 +137,10 @@ func (s *Setup) CleanConfigCredentialsForProviders() error {
 
 func (s *Setup) WriteToFile() error {
 	data, err := yaml.Marshal(s.config)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	err = os.MkdirAll(filepath.Dir(s.outputFile), os.ModePerm)
 	if err != nil {
 		return microerror.Mask(err)
 	}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/26452 https://github.com/giantswarm/giantswarm/issues/26453

I found two small bugs that can cause issues in credential creation.
- if the parent directory does not exist, it can cause an error
- the `omitempty` tag was not applied correctly due to `json` instead of `yaml` modifier. Because of that empty `customer` field could appear.