### PR TITLE
Fix bug in azure provider when update of redirect URI array fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix bug in azure provider when update of redirect URI array fails.
+
 ## [0.3.3] - 2023-03-29
 
 ### Fixed

--- a/pkg/idp/provider/azure/azure_test.go
+++ b/pkg/idp/provider/azure/azure_test.go
@@ -259,3 +259,48 @@ func TestSecretExpired(t *testing.T) {
 		})
 	}
 }
+
+func TestComputeURIUpdatePatch(t *testing.T) {
+	testCases := []struct {
+		name         string
+		URIs         []string
+		updateNeeded bool
+	}{
+		{
+			name:         "case 0",
+			URIs:         nil,
+			updateNeeded: true,
+		},
+		{
+			name:         "case 1",
+			URIs:         []string{"hi.io"},
+			updateNeeded: true,
+		},
+		{
+			name:         "case 2",
+			URIs:         []string{"hello.io"},
+			updateNeeded: false,
+		},
+		{
+			name:         "case 3",
+			URIs:         []string{"hi.io", "hello.io"},
+			updateNeeded: false,
+		},
+		{
+			name:         "case 4",
+			URIs:         []string{},
+			updateNeeded: true,
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			app := models.NewApplication()
+			app.SetWeb(getRedirectURIsRequestBody(tc.URIs))
+			updateNeeded, _ := computeRedirectURIUpdatePatch(app, provider.GetTestConfig())
+			if updateNeeded != tc.updateNeeded {
+				t.Fatalf("Expected %v, got %v", updateNeeded, tc.updateNeeded)
+			}
+		})
+	}
+}

--- a/pkg/idp/provider/azure/request.go
+++ b/pkg/idp/provider/azure/request.go
@@ -60,7 +60,7 @@ func computeRedirectURIUpdatePatch(app models.Applicationable, config provider.A
 			return false, nil
 		}
 	}
-	patch.SetRedirectUris(append(uris, config.RedirectURI))
+	patch = getRedirectURIsRequestBody(append(uris, config.RedirectURI))
 	return true, patch
 }
 


### PR DESCRIPTION
With the latest azure dependency update the operator can crash with the following error when the array of redirect URIs already exists and is updated.
```
panic: runtime error: comparing uncomparable type []string [recovered]
	panic: runtime error: comparing uncomparable type []string
```
This change fixes it.