### PR TITLE
Add predicate to app controller that recognizes MC dex app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add predicate to app controller that recognizes MC dex app even before the `app.kubernetes.io/name` label was set.
+
 ## [0.3.5] - 2023-05-10
 
 ### Changed

--- a/pkg/key/key.go
+++ b/pkg/key/key.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 const (
@@ -14,6 +15,8 @@ const (
 	DexOperatorLabelValue        = "dex-operator"
 	ClusterValuesConfigmapSuffix = "cluster-values"
 	ClusterValuesConfigMapKey    = "values"
+	MCDexAppDefaultName          = "dex-app"
+	MCDexAppDefaultNamespace     = "giantswarm"
 	UserValuesConfigMapKey       = "values"
 	BaseDomainKey                = "baseDomain"
 	ConnectorsKey                = "connectors"
@@ -33,6 +36,14 @@ func DexLabelSelector() metav1.LabelSelector {
 		},
 	}
 }
+
+func MCDexDefaultNamespacedName() types.NamespacedName {
+	return types.NamespacedName{
+		Name:      MCDexAppDefaultName,
+		Namespace: MCDexAppDefaultNamespace,
+	}
+}
+
 func GetProviderName(owner string, name string) string {
 	return fmt.Sprintf("%s-%s", owner, name)
 }


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2411

This is a fix for the issues we see with dex-operator not finding the MC dex-app when the app label is missing. We still need to solve the root cause but it'll help for now.