### PR TITLE
add migration from vintage secret format to org namespace format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Use dex app name specific naming pattern for dex config secret and add migration code for old naming pattern.
 - Add predicate to app controller that recognizes MC dex app even before the `app.kubernetes.io/name` label was set.
 
 ## [0.3.5] - 2023-05-10

--- a/controllers/app_controller_test.go
+++ b/controllers/app_controller_test.go
@@ -41,7 +41,6 @@ var _ = Describe("App controller", func() {
 	const (
 		AppName      = "test-app"
 		AppNamespace = "test-namespace"
-		SecretName   = "test-secret"
 
 		timeout  = time.Second * 10
 		duration = time.Second * 10
@@ -121,11 +120,11 @@ var _ = Describe("App controller", func() {
 				}
 				return createdApp.Spec.ExtraConfigs, nil
 			}, duration, interval).Should(Equal([]v1alpha1.AppExtraConfig{
-				idp.GetDexSecretConfig(AppNamespace),
+				idp.GetDexSecretConfig(types.NamespacedName{Name: AppName, Namespace: AppNamespace}),
 			}))
 
 			By("Checking the dex config secret was created")
-			secretLookupKey := types.NamespacedName{Name: key.DexConfigName, Namespace: AppNamespace}
+			secretLookupKey := types.NamespacedName{Name: key.GetDexConfigName(AppName), Namespace: AppNamespace}
 			createdSecret := &corev1.Secret{}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, secretLookupKey, createdSecret)
@@ -160,6 +159,107 @@ var _ = Describe("App controller", func() {
 			createdSecret = &corev1.Secret{}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, secretLookupKey, createdSecret)
+				return apierrors.IsNotFound(err)
+			}, timeout, interval).Should(BeTrue())
+		})
+	})
+	const (
+		SecondAppNamespace = "test-namespace-2"
+	)
+
+	Context("When reconciling an app with vintage dex config secret", func() {
+		It("Should update to new dex config secret", func() {
+			ctx := context.Background()
+			By("Creating the namespace")
+			namespace := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: SecondAppNamespace,
+				},
+			}
+			Expect(k8sClient.Create(ctx, namespace)).Should(Succeed())
+
+			By("Creating the app")
+			app := &v1alpha1.App{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "application.giantswarm.io/v1alpha1",
+					Kind:       "App",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      AppName,
+					Namespace: SecondAppNamespace,
+				},
+				Spec: v1alpha1.AppSpec{
+					ExtraConfigs: []v1alpha1.AppExtraConfig{
+						idp.GetVintageDexSecretConfig(SecondAppNamespace),
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, app)).Should(Succeed())
+			appLookupKey := types.NamespacedName{Name: AppName, Namespace: SecondAppNamespace}
+			createdApp := &v1alpha1.App{}
+
+			// We'll need to retry getting this newly created App, given that creation may not immediately happen.
+			Eventually(func() ([]v1alpha1.AppExtraConfig, error) {
+				err := k8sClient.Get(ctx, appLookupKey, createdApp)
+				if err != nil {
+					return nil, microerror.Mask(err)
+				}
+				return createdApp.Spec.ExtraConfigs, nil
+			}, duration, interval).Should(Equal([]v1alpha1.AppExtraConfig{
+				idp.GetVintageDexSecretConfig(SecondAppNamespace),
+			}))
+
+			By("Creating the vintage secret")
+			vintageSecret := idp.GetDefaultDexConfigSecret(key.DexConfigName, SecondAppNamespace)
+			content, err := os.ReadFile(expectedContentFile)
+			Expect(err).NotTo(HaveOccurred())
+			vintageSecret.Data[dexConfigSecretKey] = []byte(strings.TrimSpace(string(content)))
+			Expect(k8sClient.Create(ctx, vintageSecret)).Should(Succeed())
+			vintageSecretLookupKey := types.NamespacedName{Name: key.DexConfigName, Namespace: SecondAppNamespace}
+			createdvintageSecret := &corev1.Secret{}
+
+			// We'll need to retry getting this newly created Secret, given that creation may not immediately happen.
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, vintageSecretLookupKey, createdvintageSecret)
+				return err == nil
+			}, timeout, interval).Should(BeTrue())
+
+			By("Adding the label to the app")
+			app.SetLabels(map[string]string{key.AppLabel: key.DexAppLabelValue})
+			Expect(k8sClient.Update(ctx, app)).Should(Succeed())
+
+			createdApp = &v1alpha1.App{}
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, appLookupKey, createdApp)
+				return err == nil
+			}, timeout, interval).Should(BeTrue())
+			Expect(createdApp.GetLabels()[key.AppLabel]).Should(Equal(key.DexAppLabelValue))
+
+			createdApp = &v1alpha1.App{}
+			By("Checking the app extra config was added and the old one removed")
+			Eventually(func() ([]v1alpha1.AppExtraConfig, error) {
+				err := k8sClient.Get(ctx, appLookupKey, createdApp)
+				if err != nil {
+					return nil, microerror.Mask(err)
+				}
+				return createdApp.Spec.ExtraConfigs, nil
+			}, duration, interval).Should(Equal([]v1alpha1.AppExtraConfig{
+				idp.GetDexSecretConfig(types.NamespacedName{Name: AppName, Namespace: SecondAppNamespace}),
+			}))
+
+			By("Checking the dex config secret was created and contents were copied")
+			secretLookupKey := types.NamespacedName{Name: key.GetDexConfigName(AppName), Namespace: SecondAppNamespace}
+			createdSecret := &corev1.Secret{}
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, secretLookupKey, createdSecret)
+				return err == nil
+			}, timeout, interval).Should(BeTrue())
+			Expect(createdSecret.Data).ShouldNot(BeNil())
+			Expect(createdSecret.Data).Should(HaveKey(dexConfigSecretKey))
+
+			By("Checking the vintage dex config secret was deleted")
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, vintageSecretLookupKey, createdvintageSecret)
 				return apierrors.IsNotFound(err)
 			}, timeout, interval).Should(BeTrue())
 		})

--- a/pkg/idp/idp.go
+++ b/pkg/idp/idp.go
@@ -91,8 +91,14 @@ func (s *Service) Reconcile(ctx context.Context) error {
 		}
 	}
 
+	// this migrates the vintage secret format (default name in cluster namespace) to capi secret format (custom name in org namespace)
+	// TODO: this migration code can be removed after running this once
+	if err := s.migrateVintageSecret(ctx); err != nil {
+		return microerror.Mask(err)
+	}
+
 	// Add secret config to app instance
-	dexSecretConfig := GetDexSecretConfig(s.app.Namespace)
+	dexSecretConfig := GetDexSecretConfig(types.NamespacedName{Namespace: s.app.Namespace, Name: s.app.Name})
 	if !dexSecretConfigIsPresent(s.app, dexSecretConfig) {
 		s.app.Spec.ExtraConfigs = append(s.app.Spec.ExtraConfigs, dexSecretConfig)
 		if err := s.Update(ctx, s.app); err != nil {
@@ -107,11 +113,11 @@ func (s *Service) Reconcile(ctx context.Context) error {
 		if !apierrors.IsNotFound(err) {
 			return microerror.Mask(err)
 		} else {
-			secret = s.GetDefaultDexConfigSecret(dexSecretConfig.Name, dexSecretConfig.Namespace)
+			secret = GetDefaultDexConfigSecret(dexSecretConfig.Name, dexSecretConfig.Namespace)
 			if err := s.Create(ctx, secret); err != nil {
 				return microerror.Mask(err)
 			}
-			s.log.Info("Applied default dex config secret for dex app instance.")
+			s.log.Info("Created default dex config secret for dex app instance.")
 		}
 	}
 	{
@@ -144,7 +150,7 @@ func (s *Service) Reconcile(ctx context.Context) error {
 			if err := s.Update(ctx, secret); err != nil {
 				return microerror.Mask(err)
 			}
-			s.log.Info("Applied default dex config secret for dex app instance.")
+			s.log.Info("Updated default dex config secret for dex app instance.")
 		}
 	}
 
@@ -161,7 +167,7 @@ func (s *Service) Reconcile(ctx context.Context) error {
 
 func (s *Service) ReconcileDelete(ctx context.Context) error {
 	// Fetch secret if present
-	dexSecretConfig := GetDexSecretConfig(s.app.Namespace)
+	dexSecretConfig := GetDexSecretConfig(types.NamespacedName{Namespace: s.app.Namespace, Name: s.app.Name})
 	if dexSecretConfigIsPresent(s.app, dexSecretConfig) {
 		secret := &corev1.Secret{}
 		if err := s.Get(ctx, types.NamespacedName{Name: dexSecretConfig.Name, Namespace: dexSecretConfig.Namespace}, secret); err != nil {
@@ -314,7 +320,7 @@ func (s *Service) GetAppConfig(ctx context.Context) (provider.AppConfig, error) 
 	}, nil
 }
 
-func (s *Service) GetDefaultDexConfigSecret(name string, namespace string) *corev1.Secret {
+func GetDefaultDexConfigSecret(name string, namespace string) *corev1.Secret {
 	return &corev1.Secret{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Secret",
@@ -352,4 +358,53 @@ func GetIssuerAddress(baseDomain string, managementClusterIssuerAddress string, 
 		}
 	}
 	return issuerAddress
+}
+
+func (s *Service) migrateVintageSecret(ctx context.Context) error {
+	// Check for vintage secret reference
+	vintageDexSecretConfig := GetVintageDexSecretConfig(s.app.Namespace)
+	if !dexSecretConfigIsPresent(s.app, vintageDexSecretConfig) {
+		return nil
+	}
+
+	// Reference exists
+	// Fetch vintage secret
+	vintageSecret := &corev1.Secret{}
+	err := s.Get(ctx, types.NamespacedName{Name: vintageDexSecretConfig.Name, Namespace: vintageDexSecretConfig.Namespace}, vintageSecret)
+
+	// Vintage secret exists
+	if err == nil {
+		// Check if new secret is already referenced and copy old secret data to new secret if not
+		dexSecretConfig := GetDexSecretConfig(types.NamespacedName{Namespace: s.app.Namespace, Name: s.app.Name})
+		if !dexSecretConfigIsPresent(s.app, dexSecretConfig) {
+			secret := GetDefaultDexConfigSecret(dexSecretConfig.Name, dexSecretConfig.Namespace)
+			secret.Data = vintageSecret.Data
+			if err := s.Create(ctx, secret); err != nil {
+				return microerror.Mask(err)
+			}
+			s.log.Info(fmt.Sprintf("Copied data from vintage dex config secret %s to new dex config secret %s for dex app instance.", vintageDexSecretConfig.Name, dexSecretConfig.Name))
+		}
+
+		// delete old secret
+		if err := s.Delete(ctx, vintageSecret); err != nil {
+			if !apierrors.IsNotFound(err) {
+				return microerror.Mask(err)
+			}
+		} else {
+			s.log.Info("Deleted vintage dex config secret for dex app instance.")
+		}
+
+	} else if !apierrors.IsNotFound(err) {
+		return microerror.Mask(err)
+	}
+	// if we are here we can assume the secret is gone so we remove the reference
+	s.app.Spec.ExtraConfigs = removeExtraConfig(s.app.Spec.ExtraConfigs, vintageDexSecretConfig)
+	if err := s.Update(ctx, s.app); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return microerror.Mask(err)
+		}
+	} else {
+		s.log.Info("Removed vintage dex config secret reference from dex app instance.")
+	}
+	return nil
 }

--- a/pkg/idp/idp_test.go
+++ b/pkg/idp/idp_test.go
@@ -370,42 +370,42 @@ func TestRemoveExtraConfig(t *testing.T) {
 			name:           "case 0",
 			configBefore:   nil,
 			configAfter:    nil,
-			configToRemove: GetDexSecretConfig("test"),
+			configToRemove: GetVintageDexSecretConfig("test"),
 		},
 		{
 			name: "case 2",
 			configBefore: []v1alpha1.AppExtraConfig{
-				GetDexSecretConfig("test2"),
+				GetVintageDexSecretConfig("test2"),
 			},
 			configAfter: []v1alpha1.AppExtraConfig{
-				GetDexSecretConfig("test2"),
+				GetVintageDexSecretConfig("test2"),
 			},
-			configToRemove: GetDexSecretConfig("test"),
+			configToRemove: GetVintageDexSecretConfig("test"),
 		},
 		{
 			name: "case 2",
 			configBefore: []v1alpha1.AppExtraConfig{
-				GetDexSecretConfig("test"),
+				GetVintageDexSecretConfig("test"),
 			},
 			configAfter:    []v1alpha1.AppExtraConfig{},
-			configToRemove: GetDexSecretConfig("test"),
+			configToRemove: GetVintageDexSecretConfig("test"),
 		},
 		{
 			name: "case 3",
 			configBefore: []v1alpha1.AppExtraConfig{
-				GetDexSecretConfig("test"),
-				GetDexSecretConfig("test2"),
+				GetVintageDexSecretConfig("test"),
+				GetVintageDexSecretConfig("test2"),
 			},
 			configAfter: []v1alpha1.AppExtraConfig{
-				GetDexSecretConfig("test2"),
+				GetVintageDexSecretConfig("test2"),
 			},
-			configToRemove: GetDexSecretConfig("test"),
+			configToRemove: GetVintageDexSecretConfig("test"),
 		},
 		{
 			name:           "case 3",
 			configBefore:   []v1alpha1.AppExtraConfig{},
 			configAfter:    []v1alpha1.AppExtraConfig{},
-			configToRemove: GetDexSecretConfig("test"),
+			configToRemove: GetVintageDexSecretConfig("test"),
 		},
 	}
 
@@ -478,7 +478,7 @@ func TestGetOldConnectorsFromSecret(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			secret := s.GetDefaultDexConfigSecret("example", "test")
+			secret := GetDefaultDexConfigSecret("example", "test")
 			secret.Data["default"] = data
 			connectors, err := getConnectorsFromSecret(secret)
 			if err != nil {

--- a/pkg/idp/util.go
+++ b/pkg/idp/util.go
@@ -13,6 +13,7 @@ import (
 	"github.com/giantswarm/apiextensions-application/api/v1alpha1"
 	"github.com/giantswarm/microerror"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 func dexSecretConfigIsPresent(app *v1alpha1.App, dexSecretConfig v1alpha1.AppExtraConfig) bool {
@@ -69,7 +70,15 @@ func connectorsDefinedInUserConfigMap(userConfigmap *corev1.ConfigMap) bool {
 	return false
 }
 
-func GetDexSecretConfig(namespace string) v1alpha1.AppExtraConfig {
+func GetDexSecretConfig(n types.NamespacedName) v1alpha1.AppExtraConfig {
+	return v1alpha1.AppExtraConfig{
+		Kind:      "secret",
+		Name:      key.GetDexConfigName(n.Name),
+		Namespace: n.Namespace,
+		Priority:  25}
+}
+
+func GetVintageDexSecretConfig(namespace string) v1alpha1.AppExtraConfig {
 	return v1alpha1.AppExtraConfig{
 		Kind:      "secret",
 		Name:      key.DexConfigName,

--- a/pkg/key/key.go
+++ b/pkg/key/key.go
@@ -48,6 +48,10 @@ func GetProviderName(owner string, name string) string {
 	return fmt.Sprintf("%s-%s", owner, name)
 }
 
+func GetDexConfigName(name string) string {
+	return fmt.Sprintf("%s-%s", name, DexConfigName)
+}
+
 func GetIdpAppName(installation string, namespace string, name string) string {
 	return fmt.Sprintf("%s-%s-%s", installation, namespace, name)
 }


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2395

The default dex config secret used to always have the same name and be located in each cluster namespace. However, with app secrets being located in org namespaces instead of cluster namespaces, this should be changed. If two clusters in the same organization have dex installed, they should still have a separate set of credentials.
This PR changes the default dex config secret name to include the app name (since it is unique within the namespace) to solve this.
Furthermore, it adds a migration code that copies existing configuration from the old to the new secret and gets rid of the old one.