### PR TITLE
Update deployment to be PSS compliant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update deployment to be PSS compliant.
+
+### Added
+
+- Add icon to Chart.yaml.
+
 ## [0.5.1] - 2023-06-02
 
 ### Added

--- a/helm/dex-operator/Chart.yaml
+++ b/helm/dex-operator/Chart.yaml
@@ -3,6 +3,7 @@ version: [[ .Version ]]
 description: "An operator that automates the management of dex connector configurations"
 appVersion: "[[ .AppVersion ]]"
 home: "https://github.com/giantswarm/dex-operator"
+icon: https://s.giantswarm.io/app-icons/dex/2/icon_light.svg
 apiVersion: v1
 annotations:
   application.giantswarm.io/team: "bigmac"

--- a/helm/dex-operator/templates/deployment.yaml
+++ b/helm/dex-operator/templates/deployment.yaml
@@ -54,6 +54,12 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 10
         securityContext:
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          capabilities:
+            drop:
+              - ALL
           {{- with .Values.securityContext }}
             {{- . | toYaml | nindent 10 }}
           {{- end }}


### PR DESCRIPTION
This PR updates the deployment to be PSS compliant.
Towards https://github.com/giantswarm/giantswarm/issues/27338

Fixed policy violations:
```
policy disallow-capabilities-strict -> resource default/Deployment/dex-operator failed: 
1. autogen-require-drop-all: validation failure: Containers must drop `ALL` capabilities. 

policy disallow-privilege-escalation -> resource default/Deployment/dex-operator failed: 
1. autogen-privilege-escalation: validation error: Privilege escalation is disallowed. The fields 
spec.containers[*].securityContext.allowPrivilegeEscalation, spec.initContainers[*].securityContext.allowPrivilegeEscalation, and spec.ephemeralContainers[*].securityContext.allowPrivilegeEscalation must be set to `false`. rule autogen-privilege-escalation failed at path /spec/template/spec/containers/0/securityContext/allowPrivilegeEscalation/ 

policy require-run-as-nonroot -> resource default/Deployment/dex-operator failed: 
1. autogen-run-as-non-root: validation error: Running as root is not allowed. Either the field spec.securityContext.runAsNonRoot must be set to `true`, or the fields spec.containers[*].securityContext.runAsNonRoot, spec.initContainers[*].securityContext.runAsNonRoot, and spec.ephemeralContainers[*].securityContext.runAsNonRoot must be set to `true`. rule autogen-run-as-non-root[0] failed at path /spec/template/spec/securityContext/runAsNonRoot/ rule autogen-run-as-non-root[1] failed at path /spec/template/spec/containers/0/securityContext/runAsNonRoot/ 

```