### PR TITLE
Allow to configure connector names

### DIFF
--- a/controllers/test-data/default-dex-config.json
+++ b/controllers/test-data/default-dex-config.json
@@ -1,1 +1,1 @@
-{"oidc":{"giantswarm":{"connectors":[{"connectorType":"mockCallback","connectorName":"Mock Provider connector for Giant Swarm","id":"giantswarm-mock","connectorConfig":"username: test\npassword: test\n"}]}}}
+{"oidc":{"giantswarm":{"connectors":[{"connectorType":"mockCallback","connectorName":"Mock Provider for Giant Swarm","id":"giantswarm-mock","connectorConfig":"username: test\npassword: test\n"}]}}}

--- a/controllers/test-data/default-dex-config.json
+++ b/controllers/test-data/default-dex-config.json
@@ -1,1 +1,1 @@
-{"oidc":{"giantswarm":{"connectors":[{"connectorType":"mockCallback","connectorName":"mockCallback connector for giantswarm","id":"giantswarm-mock","connectorConfig":"username: test\npassword: test\n"}]}}}
+{"oidc":{"giantswarm":{"connectors":[{"connectorType":"mockCallback","connectorName":"Mock Provider connector for Giant Swarm","id":"giantswarm-mock","connectorConfig":"username: test\npassword: test\n"}]}}}

--- a/pkg/idp/provider/azure/azure.go
+++ b/pkg/idp/provider/azure/azure.go
@@ -72,7 +72,7 @@ func New(p provider.ProviderCredential, log *logr.Logger) (*Azure, error) {
 	return &Azure{
 
 		Name:         key.GetProviderName(p.Owner, p.Name),
-		Description:  p.GetConnectorDescription(ProviderConnectorType),
+		Description:  p.GetConnectorDescription(ProviderDisplayName),
 		Log:          log,
 		Type:         ProviderConnectorType,
 		Client:       client,

--- a/pkg/idp/provider/azure/azure.go
+++ b/pkg/idp/provider/azure/azure.go
@@ -26,6 +26,7 @@ import (
 
 type Azure struct {
 	Name         string
+	Description  string
 	Client       *msgraphsdk.GraphServiceClient
 	Log          *logr.Logger
 	Owner        string
@@ -71,6 +72,7 @@ func New(p provider.ProviderCredential, log *logr.Logger) (*Azure, error) {
 	return &Azure{
 
 		Name:         key.GetProviderName(p.Owner, p.Name),
+		Description:  p.GetConnectorDescription(),
 		Log:          log,
 		Type:         ProviderConnectorType,
 		Client:       client,
@@ -161,7 +163,7 @@ func (a *Azure) CreateOrUpdateApp(config provider.AppConfig, ctx context.Context
 		Connector: dex.Connector{
 			Type:   a.Type,
 			ID:     a.Name,
-			Name:   key.GetConnectorDescription(ProviderConnectorType, a.Owner),
+			Name:   a.Description,
 			Config: string(data[:]),
 		},
 		SecretEndDateTime: secret.EndDateTime,

--- a/pkg/idp/provider/azure/azure.go
+++ b/pkg/idp/provider/azure/azure.go
@@ -72,7 +72,7 @@ func New(p provider.ProviderCredential, log *logr.Logger) (*Azure, error) {
 	return &Azure{
 
 		Name:         key.GetProviderName(p.Owner, p.Name),
-		Description:  p.GetConnectorDescription(),
+		Description:  p.GetConnectorDescription(ProviderConnectorType),
 		Log:          log,
 		Type:         ProviderConnectorType,
 		Client:       client,

--- a/pkg/idp/provider/azure/request.go
+++ b/pkg/idp/provider/azure/request.go
@@ -14,6 +14,7 @@ import (
 
 const (
 	ProviderName          = "ad"
+	ProviderDisplayName   = "Azure AD"
 	ProviderConnectorType = "microsoft"
 	TenantIDKey           = "tenant-id"
 	ClientIDKey           = "client-id"

--- a/pkg/idp/provider/github/github.go
+++ b/pkg/idp/provider/github/github.go
@@ -37,6 +37,7 @@ type Github struct {
 	Client       *githubclient.Client
 	Log          *logr.Logger
 	Name         string
+	Description  string
 	Type         string
 	Owner        string
 	Organization string
@@ -71,6 +72,7 @@ func New(p provider.ProviderCredential, log *logr.Logger) (*Github, error) {
 
 	return &Github{
 		Name:         key.GetProviderName(p.Owner, p.Name),
+		Description:  p.GetConnectorDescription(),
 		Log:          log,
 		Type:         ProviderConnectorType,
 		Client:       client,
@@ -181,7 +183,7 @@ func (g *Github) CreateOrUpdateApp(config provider.AppConfig, ctx context.Contex
 		Connector: dex.Connector{
 			Type:   g.Type,
 			ID:     g.Name,
-			Name:   key.GetConnectorDescription(ProviderConnectorType, g.Owner),
+			Name:   g.Description,
 			Config: string(data[:]),
 		},
 		SecretEndDateTime: secret.EndDateTime,

--- a/pkg/idp/provider/github/github.go
+++ b/pkg/idp/provider/github/github.go
@@ -23,6 +23,7 @@ import (
 
 const (
 	ProviderName          = "github"
+	ProviderDisplayName   = "Github"
 	ProviderConnectorType = "github"
 	OrganizationKey       = "organization"
 	TeamKey               = "team"
@@ -72,7 +73,7 @@ func New(p provider.ProviderCredential, log *logr.Logger) (*Github, error) {
 
 	return &Github{
 		Name:         key.GetProviderName(p.Owner, p.Name),
-		Description:  p.GetConnectorDescription(ProviderConnectorType),
+		Description:  p.GetConnectorDescription(ProviderDisplayName),
 		Log:          log,
 		Type:         ProviderConnectorType,
 		Client:       client,

--- a/pkg/idp/provider/github/github.go
+++ b/pkg/idp/provider/github/github.go
@@ -72,7 +72,7 @@ func New(p provider.ProviderCredential, log *logr.Logger) (*Github, error) {
 
 	return &Github{
 		Name:         key.GetProviderName(p.Owner, p.Name),
-		Description:  p.GetConnectorDescription(),
+		Description:  p.GetConnectorDescription(ProviderConnectorType),
 		Log:          log,
 		Type:         ProviderConnectorType,
 		Client:       client,

--- a/pkg/idp/provider/mockprovider/mockprovider.go
+++ b/pkg/idp/provider/mockprovider/mockprovider.go
@@ -27,10 +27,10 @@ type MockProvider struct {
 
 func New(p provider.ProviderCredential) (*MockProvider, error) {
 	return &MockProvider{
-		Name:  key.GetProviderName(p.Owner, ProviderName),
+		Name:        key.GetProviderName(p.Owner, ProviderName),
 		Description: p.GetConnectorDescription(),
-		Type:  ProviderConnectorType,
-		Owner: p.Owner,
+		Type:        ProviderConnectorType,
+		Owner:       p.Owner,
 	}, nil
 }
 

--- a/pkg/idp/provider/mockprovider/mockprovider.go
+++ b/pkg/idp/provider/mockprovider/mockprovider.go
@@ -19,14 +19,16 @@ const (
 )
 
 type MockProvider struct {
-	Name  string
-	Type  string
-	Owner string
+	Name        string
+	Description string
+	Type        string
+	Owner       string
 }
 
 func New(p provider.ProviderCredential) (*MockProvider, error) {
 	return &MockProvider{
 		Name:  key.GetProviderName(p.Owner, ProviderName),
+		Description: p.GetConnectorDescription(),
 		Type:  ProviderConnectorType,
 		Owner: p.Owner,
 	}, nil
@@ -61,7 +63,7 @@ func (m *MockProvider) CreateOrUpdateApp(config provider.AppConfig, ctx context.
 		Connector: dex.Connector{
 			Type:   m.Type,
 			ID:     m.Name,
-			Name:   key.GetConnectorDescription(ProviderConnectorType, m.Owner),
+			Name:   m.Description,
 			Config: string(data[:]),
 		},
 		SecretEndDateTime: time.Now().AddDate(0, 6, 0),

--- a/pkg/idp/provider/mockprovider/mockprovider.go
+++ b/pkg/idp/provider/mockprovider/mockprovider.go
@@ -15,6 +15,7 @@ import (
 
 const (
 	ProviderName          = "mock"
+	ProviderDisplayName   = "Mock Provider"
 	ProviderConnectorType = "mockCallback"
 )
 
@@ -28,7 +29,7 @@ type MockProvider struct {
 func New(p provider.ProviderCredential) (*MockProvider, error) {
 	return &MockProvider{
 		Name:        key.GetProviderName(p.Owner, ProviderName),
-		Description: p.GetConnectorDescription(ProviderConnectorType),
+		Description: p.GetConnectorDescription(ProviderDisplayName),
 		Type:        ProviderConnectorType,
 		Owner:       p.Owner,
 	}, nil

--- a/pkg/idp/provider/mockprovider/mockprovider.go
+++ b/pkg/idp/provider/mockprovider/mockprovider.go
@@ -28,7 +28,7 @@ type MockProvider struct {
 func New(p provider.ProviderCredential) (*MockProvider, error) {
 	return &MockProvider{
 		Name:        key.GetProviderName(p.Owner, ProviderName),
-		Description: p.GetConnectorDescription(),
+		Description: p.GetConnectorDescription(ProviderConnectorType),
 		Type:        ProviderConnectorType,
 		Owner:       p.Owner,
 	}, nil

--- a/pkg/idp/provider/provider.go
+++ b/pkg/idp/provider/provider.go
@@ -38,11 +38,11 @@ type ProviderCredential struct {
 	Description string            `yaml:"description"`
 }
 
-func (c ProviderCredential) GetConnectorDescription(providerConnectorType string) string {
+func (c ProviderCredential) GetConnectorDescription(providerDisplayName string) string {
 	if c.Description != "" {
 		return c.Description
 	}
-	return key.GetDefaultConnectorDescription(providerConnectorType, c.Owner)
+	return key.GetDefaultConnectorDescription(providerDisplayName, c.Owner)
 }
 
 type ProviderApp struct {

--- a/pkg/idp/provider/provider.go
+++ b/pkg/idp/provider/provider.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/giantswarm/dex-operator/pkg/dex"
+	"github.com/giantswarm/dex-operator/pkg/key"
 
 	"github.com/giantswarm/microerror"
 	"gopkg.in/yaml.v2"
@@ -34,6 +35,14 @@ type ProviderCredential struct {
 	Name        string            `yaml:"name"`
 	Owner       string            `yaml:"owner"`
 	Credentials map[string]string `yaml:"credentials"`
+	Description string            `yaml:"description"`
+}
+
+func (c ProviderCredential) GetConnectorDescription() string {
+	if c.Description != "" {
+		return c.Description
+	}
+	return key.GetDefaultConnectorDescription(c.Name, c.Owner)
 }
 
 type ProviderApp struct {

--- a/pkg/idp/provider/provider.go
+++ b/pkg/idp/provider/provider.go
@@ -38,11 +38,11 @@ type ProviderCredential struct {
 	Description string            `yaml:"description"`
 }
 
-func (c ProviderCredential) GetConnectorDescription() string {
+func (c ProviderCredential) GetConnectorDescription(providerConnectorType string) string {
 	if c.Description != "" {
 		return c.Description
 	}
-	return key.GetDefaultConnectorDescription(c.Name, c.Owner)
+	return key.GetDefaultConnectorDescription(providerConnectorType, c.Owner)
 }
 
 type ProviderApp struct {

--- a/pkg/idp/provider/provider_test.go
+++ b/pkg/idp/provider/provider_test.go
@@ -19,7 +19,17 @@ func TestReadCredentials(t *testing.T) {
 			name:     "case 0",
 			location: "test-data/credentials",
 			credentials: []ProviderCredential{
-				{Name: "mock", Owner: key.OwnerGiantswarm, Credentials: map[string]string{"hello": "hi"}},
+				{
+					Name:        "mock",
+					Owner:       key.OwnerGiantswarm,
+					Credentials: map[string]string{"hello": "hi"},
+				},
+				{
+					Name:        "mockdesc",
+					Owner:       key.OwnerGiantswarm,
+					Description: "Mock Connector",
+					Credentials: map[string]string{"hello": "hi"},
+				},
 			},
 		},
 	}

--- a/pkg/idp/provider/test-data/credentials
+++ b/pkg/idp/provider/test-data/credentials
@@ -2,3 +2,8 @@
   owner: giantswarm
   credentials:
     hello: hi
+- name: mockdesc
+  description: Mock Connector
+  owner: giantswarm
+  credentials:
+    hello: hi

--- a/pkg/key/key.go
+++ b/pkg/key/key.go
@@ -64,7 +64,7 @@ func GetIdpAppName(installation string, namespace string, name string) string {
 }
 
 func GetDefaultConnectorDescription(connectorDisplayName string, owner string) string {
-	return fmt.Sprintf("%s connector for %s", connectorDisplayName, GetOwnerDisplayName(owner))
+	return fmt.Sprintf("%s for %s", connectorDisplayName, GetOwnerDisplayName(owner))
 }
 
 func GetOwnerDisplayName(owner string) string {

--- a/pkg/key/key.go
+++ b/pkg/key/key.go
@@ -61,7 +61,7 @@ func GetIdpAppName(installation string, namespace string, name string) string {
 	return fmt.Sprintf("%s-%s-%s", installation, namespace, name)
 }
 
-func GetConnectorDescription(connectorType string, owner string) string {
+func GetDefaultConnectorDescription(connectorType string, owner string) string {
 	return fmt.Sprintf("%s connector for %s", connectorType, owner)
 }
 

--- a/pkg/key/key.go
+++ b/pkg/key/key.go
@@ -24,6 +24,8 @@ const (
 	DexResourceURI               = "https://dex.giantswarm.io"
 	OwnerGiantswarm              = "giantswarm"
 	OwnerCustomer                = "customer"
+	OwnerGiantswarmDisplayName   = "Giant Swarm"
+	OwnerCustomerDisplayName     = "Customer"
 )
 
 const (
@@ -61,8 +63,19 @@ func GetIdpAppName(installation string, namespace string, name string) string {
 	return fmt.Sprintf("%s-%s-%s", installation, namespace, name)
 }
 
-func GetDefaultConnectorDescription(connectorType string, owner string) string {
-	return fmt.Sprintf("%s connector for %s", connectorType, owner)
+func GetDefaultConnectorDescription(connectorDisplayName string, owner string) string {
+	return fmt.Sprintf("%s connector for %s", connectorDisplayName, GetOwnerDisplayName(owner))
+}
+
+func GetOwnerDisplayName(owner string) string {
+	switch owner {
+	case OwnerGiantswarm:
+		return OwnerGiantswarmDisplayName
+	case OwnerCustomer:
+		return OwnerCustomerDisplayName
+	default:
+		return owner
+	}
 }
 
 func GetRedirectURI(issuerAddress string) string {


### PR DESCRIPTION
This PR adds the possibility to configure the connector names, by specifying the `description` key in the dex-operator credential secret. When omitting this key a default is provided that is generated through the provider and owner of the connector.

Previously, the connector name was generated with the following format: `<PROVIDER_TYPE> connector for <OWNER>`.
If the `description` key is not specified, the connector name will be generated through `<PROVIDER_DISPLAY_NAME> connector for <OWNER_DISPLAY_NAME>`.
Here `PROVIDER_DISPLAY_NAME` is a dedicated display name (mostly in title case) for the given provider and `OWNER_DISPLAY_NAME` applies similar transformations (`giantswarm` -> `Giant Swarm`). 


Towards https://github.com/giantswarm/roadmap/issues/1864
Tested on `gauss`.