### PR TITLE
Use slug in GitHub dex config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Changed GitHub connector config to include `teamNameField: slug` by default.
+
 ## [0.8.0] - 2023-08-02
 
 ### Added

--- a/pkg/idp/provider/github/github.go
+++ b/pkg/idp/provider/github/github.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -11,6 +12,7 @@ import (
 	"github.com/giantswarm/dex-operator/pkg/idp/provider"
 	"github.com/giantswarm/dex-operator/pkg/idp/provider/github/manifest"
 	"github.com/giantswarm/dex-operator/pkg/key"
+	"github.com/giantswarm/dex-operator/pkg/yaml"
 
 	"github.com/bradleyfalzon/ghinstallation/v2"
 	githubconnector "github.com/dexidp/dex/connector/github"
@@ -18,7 +20,6 @@ import (
 	"github.com/go-logr/logr"
 	githubclient "github.com/google/go-github/v50/github"
 	"github.com/skratchdot/open-golang/open"
-	"gopkg.in/yaml.v2"
 )
 
 const (
@@ -178,7 +179,7 @@ func (g *Github) CreateOrUpdateApp(config provider.AppConfig, ctx context.Contex
 		RedirectURI:   config.RedirectURI,
 		TeamNameField: TeamNameFieldSlug,
 	}
-	data, err := yaml.Marshal(connectorConfig)
+	data, err := yaml.MarshalWithJsonAnnotations(connectorConfig)
 	if err != nil {
 		return provider.ProviderApp{}, microerror.Mask(err)
 	}

--- a/pkg/idp/provider/github/github.go
+++ b/pkg/idp/provider/github/github.go
@@ -2,7 +2,6 @@ package github
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"strconv"

--- a/pkg/idp/provider/github/github.go
+++ b/pkg/idp/provider/github/github.go
@@ -32,6 +32,7 @@ const (
 	ClientIDKey           = "client-id"
 	ClientSecretKey       = "client-secret"
 	DefaultHost           = "github.com"
+	TeamNameFieldSlug     = "slug"
 )
 
 type Github struct {
@@ -174,7 +175,8 @@ func (g *Github) CreateOrUpdateApp(config provider.AppConfig, ctx context.Contex
 				Teams: []string{g.Team},
 			},
 		},
-		RedirectURI: config.RedirectURI,
+		RedirectURI:   config.RedirectURI,
+		TeamNameField: TeamNameFieldSlug,
 	}
 	data, err := yaml.Marshal(connectorConfig)
 	if err != nil {

--- a/pkg/yaml/yaml.go
+++ b/pkg/yaml/yaml.go
@@ -1,0 +1,24 @@
+package yaml
+
+import (
+	"encoding/json"
+
+	"github.com/giantswarm/microerror"
+	yamllib "gopkg.in/yaml.v2"
+)
+
+// MarshalWithJsonAnnotations marshals the given value to YAML, but uses the
+// JSON annotations of the struct fields.
+func MarshalWithJsonAnnotations(v any) ([]byte, error) {
+	jsonData, jsonErr := json.Marshal(v)
+	if jsonErr != nil {
+		return nil, microerror.Mask(jsonErr)
+	}
+	var mapData map[string]interface{}
+	jsonErr = json.Unmarshal(jsonData, &mapData)
+	if jsonErr != nil {
+		return nil, microerror.Mask(jsonErr)
+	}
+	data, yamlErr := yamllib.Marshal(mapData)
+	return data, yamlErr
+}

--- a/pkg/yaml/yaml.go
+++ b/pkg/yaml/yaml.go
@@ -3,8 +3,9 @@ package yaml
 import (
 	"encoding/json"
 
-	"github.com/giantswarm/microerror"
 	yamllib "gopkg.in/yaml.v2"
+
+	"github.com/giantswarm/microerror"
 )
 
 // MarshalWithJsonAnnotations marshals the given value to YAML, but uses the


### PR DESCRIPTION
This PR updates the default GitHub connector config to include `teamNameField: slug`.
See [the dex docs for details](https://dexidp.io/docs/connectors/github/#configuration).

As the only team we are currently using is `giantswarm-admins`, whose name and slug are equal, this won't have any effect.

Towards https://github.com/giantswarm/roadmap/issues/1205

## Note
I've also changed the yaml marshalling. The config is converted to JSON first, so that the `json` annotations on the config struct are actually used and not just a lower-case representation of the key's name.

**before:**
```yaml
- type: github
  id: giantswarm-github
  name: Github for Giant Swarm
  config:
    org: ""
    orgs:
      - name: giantswarm
        teams:
          - giantswarm-admins
    hostname: ""
    rootca: ""
    teamnamefield: ""
```
**after:**
```yaml
- type: github
  id: giantswarm-github
  name: Github for Giant Swarm
  config:
    hostName: ""
    org: ""
    orgs:
      - name: giantswarm
        teams:
          - giantswarm-admins
    rootCA: ""
    teamNameField: slug
```