### PR TITLE
Change display name from "Azure AD" to "Entra ID"

### DIFF
--- a/pkg/idp/provider/azure/request.go
+++ b/pkg/idp/provider/azure/request.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	ProviderName          = "ad"
-	ProviderDisplayName   = "Azure AD"
+	ProviderDisplayName   = "Entra ID"
 	ProviderConnectorType = "microsoft"
 	TenantIDKey           = "tenant-id"
 	ClientIDKey           = "client-id"


### PR DESCRIPTION
Microsoft has renamed the product some time ago, and in the Azure Portal the service can only be found as "Microsoft Entra ID" now. I suggest that we align with that upstream change.