### PR TITLE
Extend simpleprovider with connectorId override + central-cluster skip (TB-5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `simpleprovider`: optional `connectorId` credentials key overrides the
+  auto-derived `<owner>-simple-<connectorType>` connector ID. Used by the
+  Giant Swarm SSO federation connector (PLAN §6 TB-5) to land as
+  `id: giantswarm`.
+- `simpleprovider`: optional `centralCluster` credentials key. When the
+  operator's `--management-cluster` matches the value, the provider is
+  skipped to avoid writing a self-referencing federation connector
+  (PLAN §6 TB-5).
+
 ## [0.16.2] - 2026-03-26
 ### Added
 

--- a/controllers/app_controller.go
+++ b/controllers/app_controller.go
@@ -222,6 +222,12 @@ func (r *AppReconciler) GetProviders() ([]provider.Provider, error) {
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
+		// A nil provider with no error means the constructor opted out of
+		// running on this management cluster (e.g. simpleprovider's
+		// centralCluster skip — see PLAN §6 TB-5).
+		if provider == nil {
+			continue
+		}
 		providers = append(providers, provider)
 	}
 	return providers, nil
@@ -270,7 +276,17 @@ func NewProvider(config provider.ProviderConfig) (provider.Provider, error) {
 	case github.ProviderName:
 		return github.New(config)
 	case simpleprovider.ProviderName:
-		return simpleprovider.New(config)
+		// simpleprovider.New may return (nil, nil) to opt out (centralCluster
+		// skip; see PLAN §6 TB-5). Return an untyped nil interface so callers
+		// can compare against nil reliably.
+		p, err := simpleprovider.New(config)
+		if err != nil {
+			return nil, err
+		}
+		if p == nil {
+			return nil, nil
+		}
+		return p, nil
 	}
 	return nil, microerror.Maskf(invalidConfigError, "%s is not a valid provider name.", config.Credential.Name)
 }

--- a/controllers/helmrelease_controller.go
+++ b/controllers/helmrelease_controller.go
@@ -202,6 +202,12 @@ func (r *HelmReleaseReconciler) GetProviders() ([]provider.Provider, error) {
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
+		// A nil provider with no error means the constructor opted out of
+		// running on this management cluster (e.g. simpleprovider's
+		// centralCluster skip — see PLAN §6 TB-5).
+		if provider == nil {
+			continue
+		}
 		providers = append(providers, provider)
 	}
 	return providers, nil

--- a/pkg/idp/provider/simpleprovider/simpleprovider.go
+++ b/pkg/idp/provider/simpleprovider/simpleprovider.go
@@ -23,11 +23,39 @@ const (
 	ProviderType        = "simple"
 	connectorTypeKey    = "connectorType"
 	connectorConfigKey  = "connectorConfig"
+
+	// CredentialKeyConnectorID is an optional credentials key. When set and
+	// non-empty, it overrides the auto-derived connector ID
+	// (`<owner>-simple-<connectorType>`) with the literal value provided.
+	// Used by the Giant Swarm SSO federation connector (PLAN §6 TB-5) which
+	// must land as `id: giantswarm` to match production MCPServer CRs.
+	// Validated against the same identifier pattern Muster's
+	// MCPServerAuth.TokenExchange.ConnectorID enforces.
+	CredentialKeyConnectorID = "connectorId"
+
+	// CredentialKeyCentralCluster is an optional credentials key naming the
+	// management cluster whose Dex this connector federates to. When the
+	// operator's own --management-cluster matches this value, the provider is
+	// skipped to avoid writing a self-referencing connector (PLAN §6 TB-5).
+	CredentialKeyCentralCluster = "centralCluster"
 )
+
+// connectorIDPattern matches the identifier pattern enforced by Muster's
+// MCPServerAuth.TokenExchange.ConnectorID (PLAN §5 Gap D).
+var connectorIDPattern = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9_-]*$`)
 
 // The simple provider is a provider that can be used if no idp access is configured for the operator.
 // It can also be used in case the idp in question is not supported by the operator.
 // It will create a connector with the given type and config.
+//
+// Recognised credentials keys:
+//   - connectorType   (required) - dex connector type (e.g. "oidc", "ldap")
+//   - connectorConfig (required) - YAML body of the dex connector config
+//   - connectorId     (optional) - literal connector ID override; defaults to
+//     "<owner>-simple-<connectorType>" when unset
+//   - centralCluster  (optional) - skip this provider when the operator runs
+//     on this management cluster (avoids self-referencing federation
+//     connectors; see PLAN §6 TB-5)
 type SimpleProvider struct {
 	Log             logr.Logger
 	Name            string
@@ -41,19 +69,42 @@ type SimpleProvider struct {
 type Config struct {
 	connectorType   string
 	connectorConfig string
+	connectorID     string
 }
 
 var _ provider.Provider = (*SimpleProvider)(nil)
 
 func New(config provider.ProviderConfig) (*SimpleProvider, error) {
+	// Central-cluster skip (PLAN §6 TB-5): if this credential targets the
+	// management cluster the operator itself runs on, do not create a
+	// connector — that would be a self-referencing federation connector.
+	// Returning (nil, nil) tells the caller to skip this credential.
+	if central := config.Credential.Credentials[CredentialKeyCentralCluster]; central != "" &&
+		config.ManagementClusterName != "" &&
+		central == config.ManagementClusterName {
+		if (logr.Logger{}) != config.Log {
+			config.Log.Info(fmt.Sprintf(
+				"Skipping simpleprovider credential %q: centralCluster %q matches operator's management cluster (avoids self-referencing connector)",
+				config.Credential.Name, central))
+		}
+		return nil, nil
+	}
+
 	// get configuration from credentials
 	c, err := newSimpleConfig(config.Credential, config.Log)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
 
+	// Connector ID: prefer the explicit override when provided, otherwise
+	// fall back to today's auto-derived `<owner>-simple-<connectorType>`.
+	name := c.connectorID
+	if name == "" {
+		name = key.GetProviderName(config.Credential.Owner, fmt.Sprintf("%s-%s", ProviderName, c.connectorType))
+	}
+
 	return &SimpleProvider{
-		Name:            key.GetProviderName(config.Credential.Owner, fmt.Sprintf("%s-%s", ProviderName, c.connectorType)),
+		Name:            name,
 		Description:     config.Credential.GetConnectorDescription(ProviderDisplayName),
 		Type:            ProviderType,
 		Owner:           config.Credential.Owner,
@@ -84,9 +135,20 @@ func newSimpleConfig(p provider.ProviderCredential, log logr.Logger) (Config, er
 		}
 	}
 
+	// Optional connector ID override. When unset, the caller derives the ID
+	// from owner + connector type (today's behaviour). When set, we validate
+	// the format eagerly so misconfiguration surfaces at startup rather than
+	// causing dex to reject the secret on reload.
+	connectorID := p.Credentials[CredentialKeyConnectorID]
+	if connectorID != "" && !connectorIDPattern.MatchString(connectorID) {
+		return Config{}, microerror.Maskf(invalidConfigError,
+			"%s %q is invalid: must match %s", CredentialKeyConnectorID, connectorID, connectorIDPattern.String())
+	}
+
 	return Config{
 		connectorType:   connectorType,
 		connectorConfig: connectorConfig,
+		connectorID:     connectorID,
 	}, nil
 }
 

--- a/pkg/idp/provider/simpleprovider/simpleprovider_test.go
+++ b/pkg/idp/provider/simpleprovider/simpleprovider_test.go
@@ -224,3 +224,162 @@ func TestCreateApp(t *testing.T) {
 		})
 	}
 }
+
+// TestConnectorIDOverride covers the optional connectorId credentials key
+// added for the Giant Swarm SSO federation connector (PLAN §6 TB-5).
+func TestConnectorIDOverride(t *testing.T) {
+	testCases := []struct {
+		name            string
+		connectorID     string
+		expectedID      string
+		expectNewError  bool
+		expectAppError  bool
+	}{
+		{
+			name:        "case 0 - override unset falls back to auto-derived ID",
+			connectorID: "",
+			expectedID:  "test-simple-oidc",
+		},
+		{
+			name:        "case 1 - explicit canonical giantswarm ID",
+			connectorID: "giantswarm",
+			expectedID:  "giantswarm",
+		},
+		{
+			name:        "case 2 - alphanumeric with dashes and underscores",
+			connectorID: "gs_sso-2",
+			expectedID:  "gs_sso-2",
+		},
+		{
+			name:           "case 3 - leading digit rejected",
+			connectorID:    "1giantswarm",
+			expectNewError: true,
+		},
+		{
+			name:           "case 4 - invalid character rejected",
+			connectorID:    "giantswarm.sso",
+			expectNewError: true,
+		},
+		{
+			name:           "case 5 - whitespace rejected",
+			connectorID:    "giant swarm",
+			expectNewError: true,
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			credential := provider.ProviderCredential{
+				Name:  "name",
+				Owner: "test",
+				Credentials: map[string]string{
+					connectorTypeKey:           "oidc",
+					connectorConfigKey:         "issuer: https://dex.example.com\nclientID: 123\nclientSecret: abc\nredirectURI: hi.io",
+					CredentialKeyConnectorID:   tc.connectorID,
+				},
+			}
+			providerConfig := provider.ProviderConfig{
+				Credential: credential,
+				Log:        provider.GetTestLogger(),
+			}
+			simple, err := New(providerConfig)
+			if tc.expectNewError {
+				if err == nil {
+					t.Fatalf("Expected error from New, got success.")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			app, err := simple.CreateOrUpdateApp(provider.GetTestConfig(), context.Background(), dex.Connector{})
+			if err != nil && !tc.expectAppError {
+				t.Fatal(err)
+			}
+			if app.Connector.ID != tc.expectedID {
+				t.Fatalf("Expected connector ID %q, got %q", tc.expectedID, app.Connector.ID)
+			}
+			// Connector Name (description) is unaffected by the override.
+			if app.Connector.Name != "Simple Provider for test" {
+				t.Fatalf("Expected connector Name %q, got %q", "Simple Provider for test", app.Connector.Name)
+			}
+		})
+	}
+}
+
+// TestCentralClusterSkip covers the central-cluster skip (PLAN §6 TB-5):
+// simpleprovider.New returns (nil, nil) when the operator's
+// --management-cluster matches the credential's centralCluster value.
+func TestCentralClusterSkip(t *testing.T) {
+	baseCredentials := map[string]string{
+		connectorTypeKey:   "oidc",
+		connectorConfigKey: "issuer: https://dex.example.com\nclientID: 123\nclientSecret: abc\nredirectURI: hi.io",
+	}
+
+	testCases := []struct {
+		name              string
+		centralCluster    string
+		operatorCluster   string
+		expectSkip        bool
+	}{
+		{
+			name:            "case 0 - match - operator on central cluster - skip",
+			centralCluster:  "gazelle",
+			operatorCluster: "gazelle",
+			expectSkip:      true,
+		},
+		{
+			name:            "case 1 - mismatch - operator on remote MC - run",
+			centralCluster:  "gazelle",
+			operatorCluster: "glean",
+			expectSkip:      false,
+		},
+		{
+			name:            "case 2 - centralCluster unset - run",
+			centralCluster:  "",
+			operatorCluster: "gazelle",
+			expectSkip:      false,
+		},
+		{
+			name:            "case 3 - operatorCluster unset - run (would skip nothing)",
+			centralCluster:  "gazelle",
+			operatorCluster: "",
+			expectSkip:      false,
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			creds := map[string]string{}
+			for k, v := range baseCredentials {
+				creds[k] = v
+			}
+			if tc.centralCluster != "" {
+				creds[CredentialKeyCentralCluster] = tc.centralCluster
+			}
+
+			providerConfig := provider.ProviderConfig{
+				Credential: provider.ProviderCredential{
+					Name:        "name",
+					Owner:       "giantswarm",
+					Credentials: creds,
+				},
+				Log:                   provider.GetTestLogger(),
+				ManagementClusterName: tc.operatorCluster,
+			}
+			simple, err := New(providerConfig)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if tc.expectSkip {
+				if simple != nil {
+					t.Fatalf("Expected nil provider (skip), got %+v", simple)
+				}
+				return
+			}
+			if simple == nil {
+				t.Fatalf("Expected non-nil provider, got nil (unexpected skip)")
+			}
+		})
+	}
+}

--- a/pkg/idp/provider/simpleprovider/simpleprovider_test.go
+++ b/pkg/idp/provider/simpleprovider/simpleprovider_test.go
@@ -229,11 +229,11 @@ func TestCreateApp(t *testing.T) {
 // added for the Giant Swarm SSO federation connector (PLAN §6 TB-5).
 func TestConnectorIDOverride(t *testing.T) {
 	testCases := []struct {
-		name            string
-		connectorID     string
-		expectedID      string
-		expectNewError  bool
-		expectAppError  bool
+		name           string
+		connectorID    string
+		expectedID     string
+		expectNewError bool
+		expectAppError bool
 	}{
 		{
 			name:        "case 0 - override unset falls back to auto-derived ID",
@@ -273,9 +273,9 @@ func TestConnectorIDOverride(t *testing.T) {
 				Name:  "name",
 				Owner: "test",
 				Credentials: map[string]string{
-					connectorTypeKey:           "oidc",
-					connectorConfigKey:         "issuer: https://dex.example.com\nclientID: 123\nclientSecret: abc\nredirectURI: hi.io",
-					CredentialKeyConnectorID:   tc.connectorID,
+					connectorTypeKey:         "oidc",
+					connectorConfigKey:       "issuer: https://dex.example.com\nclientID: 123\nclientSecret: abc\nredirectURI: hi.io",
+					CredentialKeyConnectorID: tc.connectorID,
 				},
 			}
 			providerConfig := provider.ProviderConfig{
@@ -317,10 +317,10 @@ func TestCentralClusterSkip(t *testing.T) {
 	}
 
 	testCases := []struct {
-		name              string
-		centralCluster    string
-		operatorCluster   string
-		expectSkip        bool
+		name            string
+		centralCluster  string
+		operatorCluster string
+		expectSkip      bool
 	}{
 		{
 			name:            "case 0 - match - operator on central cluster - skip",


### PR DESCRIPTION
## Summary

Two minimal changes to support the cross-cluster Dex federation that Muster-on-Gazelle needs to reach customer-MC Dexes:

1. **\`simpleprovider\` connectorId override** — adds optional \`connectorId\` (and \`centralCluster\`) credential keys. When \`connectorId\` is set, it overrides the auto-derived \`<owner>-simple-<connectorType>\` ID at \`simpleprovider.go:55-62\`. The connector \`Name\` (from \`s.Description\`) is unaffected. Validates against \`^[a-zA-Z][a-zA-Z0-9_-]*$\` (matching Muster's \`MCPServerAuth.TokenExchange.ConnectorID\` regex).

2. **Central-cluster skip** — when the target MC matches the operator's own \`--management-cluster\` flag, the provider returns \`(nil, nil)\` to skip writing a self-referencing connector. Plumbed via existing \`ProviderConfig.ManagementClusterName\`.

This unblocks the canonical \`id: giantswarm\` connector (decoupled from cluster name; locked 2026-04-29) on remote MCs without forcing the auto-derived ID. Closed-not-merged dex-operator#150 (which added a dedicated \`giantswarmsso\` provider) is replaced by this much smaller diff.

## Dependencies / stacking

- **Depends on:** none. Independent of all muster work.
- **Pairs with:** dex-app values per cluster (no chart change needed — verified the existing \`oidc.giantswarm.connectors[]\` slot at \`helm/dex-app/templates/secret-gs.yaml:154-162\` already accepts what dex-operator emits).
- **Functional pair (different repo):** muster's token-exchange path (TB-0/8 in muster) hits \`auth.tokenExchange.connectorId: giantswarm\` against remote MCs.

## Testing

- \`go build/vet/test ./...\` all green
- New unit tests: 6 connectorId override cases + 4 central-cluster-skip cases (table-test style matching existing fixtures)

## Context

Part of [giantswarm/giantswarm#35456](https://github.com/giantswarm/giantswarm/issues/35456) cross-cutting prerequisite (PLAN §5 Gap D). Replaces the closed-not-merged dex-operator#150.

---
🚧 **Draft / WIP**.